### PR TITLE
remove hardcoded kind: Role

### DIFF
--- a/charts/my-bloody-jenkins/Chart.yaml
+++ b/charts/my-bloody-jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 name: my-bloody-jenkins
-version: 0.1.19
+version: 0.1.20
 appVersion: "2.150.2-106"
 icon: https://wiki.jenkins-ci.org/download/attachments/2916393/logo.png
 description: >

--- a/charts/my-bloody-jenkins/README.md
+++ b/charts/my-bloody-jenkins/README.md
@@ -11,7 +11,7 @@ The chart will do the following:
 * Optionally expose Jenkins with [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/)
 * Manages a [Persistent Volume Claim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) for Jenkins Storage
 * Optionally mount extenral [secrets](https://kubernetes.io/docs/concepts/configuration/secret/) as volumes to be used within the configuration [See docs](https://github.com/odavid/my-bloody-jenkins/pull/102)
-* Optionally mount extenral [configMaps](https://kubernetes-v1-4.github.io/docs/user-guide/configmap/) to be used as configuration data sources [See docs](https://github.com/odavid/my-bloody-jenkins/pull/102)
+* Optionally mount external [configMaps](https://kubernetes-v1-4.github.io/docs/user-guide/configmap/) to be used as configuration data sources [See docs](https://github.com/odavid/my-bloody-jenkins/pull/102)
 * Optionally configures [rbac](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) and a dedicated [service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
 
 

--- a/charts/my-bloody-jenkins/templates/rbac.yaml
+++ b/charts/my-bloody-jenkins/templates/rbac.yaml
@@ -8,7 +8,6 @@ metadata:
 
 ---
 kind: {{ if .Values.rbac.clusterWideAccess }}"ClusterRole"{{ else }}"Role"{{ end }}
-kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
`kind: Role` was barcoded, which didn't allow to switch to `ClusterRole`